### PR TITLE
Make `WithNewConnection` exception safe

### DIFF
--- a/effectful-hpqtypes.cabal
+++ b/effectful-hpqtypes.cabal
@@ -41,6 +41,7 @@ library
     , effectful          ^>=0.1
     , exceptions
     , hpqtypes           ==1.9.4.0
+    , lifted-base
     , text
     , transformers-base
 

--- a/effectful-hpqtypes.cabal
+++ b/effectful-hpqtypes.cabal
@@ -41,7 +41,6 @@ library
     , effectful          ^>=0.1
     , exceptions
     , hpqtypes           ==1.9.4.0
-    , lifted-base
     , text
     , transformers-base
 

--- a/src/Effectful/HPQTypes.hs
+++ b/src/Effectful/HPQTypes.hs
@@ -17,9 +17,8 @@ module Effectful.HPQTypes
 where
 
 import Control.Concurrent.MVar (readMVar)
-import Control.Exception.Lifted (bracket)
 import Control.Monad.Base (MonadBase, liftBase)
-import Control.Monad.Catch (MonadMask)
+import Control.Monad.Catch (MonadMask, bracket)
 import qualified Database.PostgreSQL.PQTypes as PQ
 import qualified Database.PostgreSQL.PQTypes.Internal.Connection as PQ
 import qualified Database.PostgreSQL.PQTypes.Internal.Notification as PQ


### PR DESCRIPTION
Makes sure to retrieve the original `ConnectionSource` even if `withConnection` closes the new connection after an exception.

closes #21 