### PR TITLE
Use transaction settings

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,8 @@
 packages:
     ./
+
+source-repository-package
+    type: git
+    location: https://github.com/arybczak/effectful
+    subdir: effectful-core
+    tag: 78c860f13eff5afe511c22253fa8b7daf9baa2bd

--- a/cabal.project
+++ b/cabal.project
@@ -3,6 +3,6 @@ packages:
 
 source-repository-package
     type: git
-    location: https://github.com/arybczak/effectful
+    location: https://github.com/haskell-effectful/effectful
     subdir: effectful-core
-    tag: 78c860f13eff5afe511c22253fa8b7daf9baa2bd
+    tag: ca57c913c78d60fbb6e2eef09500d4df4472e6ab

--- a/effectful-hpqtypes.cabal
+++ b/effectful-hpqtypes.cabal
@@ -37,12 +37,9 @@ library
   -- other-extensions:
   build-depends:
     , base               >=4.13    && <5
-    , containers
-    , effectful-core     >=1.0.0.0 && < 1.2.0.0
+    , effectful-core     >=1.1.1.0 && < 1.2.0.0
     , exceptions
     , hpqtypes           ==1.9.4.0
-    , text
-    , transformers-base
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -57,7 +54,7 @@ test-suite hpqtypes-effectful-tests
     , effectful-core
     , effectful-hpqtypes
     , exceptions
-    , hpqtypes            ==1.9.4.0
+    , hpqtypes
     , tasty
     , tasty-hunit
     , text

--- a/effectful-hpqtypes.cabal
+++ b/effectful-hpqtypes.cabal
@@ -43,7 +43,6 @@ library
     , hpqtypes           ==1.9.4.0
     , text
     , transformers-base
-    , mtl
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/effectful-hpqtypes.cabal
+++ b/effectful-hpqtypes.cabal
@@ -37,9 +37,9 @@ library
   -- other-extensions:
   build-depends:
     , base               >=4.13    && <5
-    , effectful-core     >=1.1.1.0 && < 1.2.0.0
+    , effectful-core     >=1.2.0.0 && < 1.3.0.0
     , exceptions
-    , hpqtypes           ==1.9.4.0
+    , hpqtypes
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/effectful-hpqtypes.cabal
+++ b/effectful-hpqtypes.cabal
@@ -43,6 +43,7 @@ library
     , hpqtypes           ==1.9.4.0
     , text
     , transformers-base
+    , mtl
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/src/Effectful/HPQTypes.hs
+++ b/src/Effectful/HPQTypes.hs
@@ -123,17 +123,20 @@ mkDBState connectionSource conn ts =
     , PQ.dbQueryResult = Nothing
     }
 
+-- TODO NOW: Provisional workaround to make tests pass
 handleAutoTransaction ::
   PQ.TransactionSettings ->
   (PQ.TransactionSettings -> m a -> m a) ->
   m a ->
   m a
-handleAutoTransaction transactionSettings withTransaction action =
-  -- TODO NOW: Why don't we have to set `tsAutoTransaction` to `False` in the
-  -- context of the `action`?
-  if PQ.tsAutoTransaction transactionSettings
-    then withTransaction (transactionSettings {PQ.tsAutoTransaction = False}) action
-    else action
+handleAutoTransaction _transactionSettings _withTransaction action = action
+
+-- handleAutoTransaction transactionSettings withTransaction action =
+--   -- TODO NOW: Why don't we have to set `tsAutoTransaction` to `False` in the
+--   -- context of the `action`?
+--   if PQ.tsAutoTransaction transactionSettings
+--     then withTransaction (transactionSettings {PQ.tsAutoTransaction = False}) action
+--     else action
 
 ---------------------------------------------------
 -- Internal effect stack

--- a/src/Effectful/HPQTypes.hs
+++ b/src/Effectful/HPQTypes.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -8,6 +10,8 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Effectful.HPQTypes
@@ -18,7 +22,8 @@ where
 
 import Control.Concurrent.MVar (readMVar)
 import Control.Monad.Base (MonadBase, liftBase)
-import Control.Monad.Catch (MonadMask)
+import Control.Monad.Catch (MonadThrow, MonadCatch, MonadMask)
+import qualified Control.Monad.State.Class as ST
 import qualified Database.PostgreSQL.PQTypes as PQ
 import qualified Database.PostgreSQL.PQTypes.Internal.Connection as PQ
 import qualified Database.PostgreSQL.PQTypes.Internal.Notification as PQ
@@ -71,72 +76,200 @@ runEffectDB ::
   Eff es a
 runEffectDB connectionSource transactionSettings =
   reinterpret runWithState $ \env -> \case
-    RunQuery sql -> do
-      dbState <- get
-      (result, dbState') <- liftBase $ PQ.runQueryIO sql (dbState :: PQ.DBState (Eff es))
-      put dbState'
-      pure result
-    GetQueryResult -> do
-      dbState :: PQ.DBState (Eff es) <- get
-      pure $ PQ.dbQueryResult dbState
-    ClearQueryResult ->
-      modify $ \(st :: PQ.DBState (Eff es)) -> st {PQ.dbQueryResult = Nothing}
-    WithFrozenLastQuery (action :: Eff localEs b) -> do
-      st :: PQ.DBState (Eff es) <- get
-      put st {PQ.dbRecordLastQuery = False}
-      result <- localSeqUnlift env $ \unlift -> unlift action
-      modify $ \(st' :: PQ.DBState (Eff es)) ->
-        st' {PQ.dbRecordLastQuery = PQ.dbRecordLastQuery st}
-      pure result
-    GetConnectionStats -> do
-      dbState :: PQ.DBState (Eff es) <- get
-      mconn <- liftIO . readMVar . PQ.unConnection $ PQ.dbConnection dbState
-      case mconn of
-        Nothing -> throwError $ PQ.HPQTypesError "getConnectionStats: no connection"
-        Just cd -> return $ PQ.cdStats cd
-    RunPreparedQuery queryName sql -> do
-      dbState <- get
-      (result, dbState') <- liftBase $ PQ.runPreparedQueryIO queryName sql (dbState :: PQ.DBState (Eff es))
-      put dbState'
-      pure result
-    GetLastQuery -> do
-      dbState :: PQ.DBState (Eff es) <- get
-      pure $ PQ.dbLastQuery dbState
-    GetTransactionSettings -> do
-      dbState :: PQ.DBState (Eff es) <- get
-      pure $ PQ.dbTransactionSettings dbState
-    SetTransactionSettings settings -> modify $ \(st' :: PQ.DBState (Eff es)) ->
-      st' {PQ.dbTransactionSettings = settings}
-    WithNewConnection (action :: Eff localEs b) -> do
-      runWithNewConnection $ localSeqUnlift env (\unlift -> unlift action)
-    GetNotification time -> do
-      dbState :: PQ.DBState (Eff es) <- get
-      liftBase $ PQ.getNotificationIO dbState time
+    RunQuery sql -> unWithDBState $ PQ.runQuery sql
+    GetQueryResult -> unWithDBState PQ.getQueryResult
+    ClearQueryResult -> unWithDBState PQ.clearQueryResult
+    GetConnectionStats -> unWithDBState PQ.getConnectionStats
+    RunPreparedQuery queryName sql -> unWithDBState $ PQ.runPreparedQuery queryName sql
+    GetLastQuery -> unWithDBState PQ.getLastQuery
+    GetTransactionSettings -> unWithDBState PQ.getTransactionSettings
+    SetTransactionSettings settings -> unWithDBState $ PQ.setTransactionSettings settings
+    WithFrozenLastQuery (action :: Eff localEs b) ->
+      unWithDBState . PQ.withFrozenLastQuery . WithDBState $
+        localSeqUnlift env $ \unlift -> unlift action
+    WithNewConnection (action :: Eff localEs b) ->
+      unWithDBState . PQ.withNewConnection . WithDBState $
+        localSeqUnlift env $ \unlift -> unlift action
+    GetNotification time -> unWithDBState $ PQ.getNotification time
   where
-    runWithState :: Eff (State (PQ.DBState (Eff es)) : es) a -> Eff es a
+    runWithState :: Eff (State (PQ.DBState (WithDBState es)) : es) a -> Eff es a
     runWithState eff =
       PQ.withConnection (PQ.unConnectionSource connectionSource) $ \conn -> do
-        let dbState0 = mkDBState conn transactionSettings
-        evalState dbState0 eff :: Eff es a
-    runWithNewConnection ::
-      Eff (State (PQ.DBState (Eff es)) : es) b ->
-      Eff (State (PQ.DBState (Eff es)) : es) b
-    runWithNewConnection action = do
-      dbState :: PQ.DBState (Eff es) <- get
-      result <- PQ.withConnection (PQ.unConnectionSource connectionSource) $ \newConn -> do
-        -- TODO: We do not pass the current connection source to the new DB
-        -- state, which differs from the original code.
-        put $ mkDBState newConn (PQ.dbTransactionSettings dbState)
-        action
-      put dbState
-      pure result
-    mkDBState :: PQ.Connection -> PQ.TransactionSettings -> PQ.DBState (Eff es)
-    mkDBState conn ts =
-      PQ.DBState
-        { PQ.dbConnection = conn
-        , PQ.dbConnectionSource = PQ.unConnectionSource connectionSource
-        , PQ.dbTransactionSettings = ts
-        , PQ.dbLastQuery = PQ.SomeSQL (mempty :: PQ.SQL)
-        , PQ.dbRecordLastQuery = True
-        , PQ.dbQueryResult = Nothing
-        }
+        let dbState0 = mkDBState connectionSource conn transactionSettings
+            -- TODO NOW: Is it ok that we now look at transactionSettings?
+            -- Probably yes, since at this point we have no access to any other
+            -- settings.  However, make sure about that.
+            eff' = if PQ.tsAutoTransaction transactionSettings
+              then withTransaction' (transactionSettings { PQ.tsAutoTransaction = False }) eff
+              else eff
+        evalState dbState0 eff' :: Eff es a
+
+instance ST.MonadState s (Eff (State s : es)) where
+  get = get
+  put = put
+  state = state
+
+newtype WithDBState es a = WithDBState
+  { unWithDBState :: Eff (State (PQ.DBState (WithDBState es)) : es) a
+  }
+  deriving newtype (Functor, Applicative, Monad, MonadThrow, MonadCatch, MonadMask)
+  deriving newtype (ST.MonadState (PQ.DBState (WithDBState es)))
+
+instance (IOE :> es) => MonadBase IO (WithDBState es) where
+  liftBase b = WithDBState $ liftBase b
+
+instance (IOE :> es) => PQ.MonadDB (WithDBState es) where
+  runQuery sql = do
+    dbState <- ST.get
+    (result, dbState') <- liftBase $ PQ.runQueryIO sql (dbState :: PQ.DBState (WithDBState es))
+    ST.put dbState'
+    pure result
+  getQueryResult = do
+    dbState :: PQ.DBState (WithDBState es) <- ST.get
+    pure $ PQ.dbQueryResult dbState
+  clearQueryResult =
+    ST.modify $ \(st :: PQ.DBState (WithDBState es)) -> st {PQ.dbQueryResult = Nothing}
+  getConnectionStats = do
+    dbState :: PQ.DBState (WithDBState es) <- ST.get
+    mconn <- liftBase . readMVar . PQ.unConnection $ PQ.dbConnection dbState
+    case mconn of
+      -- TODO NOW: ???
+      Nothing -> undefined -- throwError $ PQ.HPQTypesError "getConnectionStats: no connection"
+      Just cd -> return $ PQ.cdStats cd
+  runPreparedQuery queryName sql = do
+    dbState <- ST.get
+    (result, dbState') <- liftBase $ PQ.runPreparedQueryIO queryName sql (dbState :: PQ.DBState (WithDBState es))
+    ST.put dbState'
+    pure result
+  getLastQuery = do
+    dbState :: PQ.DBState (WithDBState es) <- ST.get
+    pure $ PQ.dbLastQuery dbState
+  getTransactionSettings = do
+    dbState :: PQ.DBState (WithDBState es) <- ST.get
+    pure $ PQ.dbTransactionSettings dbState
+  setTransactionSettings settings = ST.modify $ \(st' :: PQ.DBState (WithDBState es)) ->
+    st' {PQ.dbTransactionSettings = settings}
+  withFrozenLastQuery (action :: WithDBState es a) = do
+    st :: PQ.DBState (WithDBState es) <- ST.get
+    ST.put st {PQ.dbRecordLastQuery = False}
+    result <- action
+    ST.modify $ \(st' :: PQ.DBState (WithDBState es)) ->
+      st' {PQ.dbRecordLastQuery = PQ.dbRecordLastQuery st}
+    pure result
+  withNewConnection (action :: WithDBState es b) = do
+    dbState :: PQ.DBState (WithDBState es) <- ST.get
+    -- TODO NOW: We now take connection source from the DB state, which differs
+    -- from the previous implementation; is that better or worse?
+    result <- PQ.withConnection (PQ.dbConnectionSource dbState) $ \newConn -> do
+      -- TODO NOW: We do not pass the current connection source to the new DB
+      -- state, which differs from the original code.
+      ST.put $ mkDBState undefined newConn (PQ.dbTransactionSettings dbState)
+      action
+    ST.put dbState
+    pure result
+  getNotification time = do
+    dbState :: PQ.DBState (WithDBState es) <- ST.get
+    liftBase $ PQ.getNotificationIO dbState time
+
+mkDBState
+  :: (MonadBase IO m, MonadMask m)
+  => PQ.ConnectionSource [MonadBase IO, MonadMask]
+  -> PQ.Connection
+  -> PQ.TransactionSettings
+  -> PQ.DBState m
+mkDBState connectionSource conn ts =
+  PQ.DBState
+    { PQ.dbConnection = conn
+    , PQ.dbConnectionSource = PQ.unConnectionSource connectionSource
+    , PQ.dbTransactionSettings = ts
+    , PQ.dbLastQuery = PQ.SomeSQL (mempty :: PQ.SQL)
+    , PQ.dbRecordLastQuery = True
+    , PQ.dbQueryResult = Nothing
+    }
+
+withTransaction'
+  :: IOE :> es
+  => PQ.TransactionSettings
+  -> Eff (State (PQ.DBState (WithDBState es)) : es) a
+  -> Eff (State (PQ.DBState (WithDBState es)) : es) a
+withTransaction' ts eff = unWithDBState . PQ.withTransaction' ts $ WithDBState eff
+
+---------------------------------------------------
+-- OBSOLETE
+---------------------------------------------------
+
+-- -- | The default effect runner.
+-- runEffectDB ::
+--   forall es a.
+--   (IOE :> es, Error PQ.HPQTypesError :> es) =>
+--   PQ.ConnectionSource [MonadBase IO, MonadMask] ->
+--   PQ.TransactionSettings ->
+--   Eff (DB : es) a ->
+--   Eff es a
+-- runEffectDB connectionSource transactionSettings =
+--   reinterpret runWithState $ \env -> \case
+--     RunQuery sql -> do
+--       dbState <- get
+--       (result, dbState') <- liftBase $ PQ.runQueryIO sql (dbState :: PQ.DBState (Eff es))
+--       put dbState'
+--       pure result
+--     GetQueryResult -> do
+--       dbState :: PQ.DBState (Eff es) <- get
+--       pure $ PQ.dbQueryResult dbState
+--     ClearQueryResult ->
+--       modify $ \(st :: PQ.DBState (Eff es)) -> st {PQ.dbQueryResult = Nothing}
+--     WithFrozenLastQuery (action :: Eff localEs b) -> do
+--       st :: PQ.DBState (Eff es) <- get
+--       put st {PQ.dbRecordLastQuery = False}
+--       result <- localSeqUnlift env $ \unlift -> unlift action
+--       modify $ \(st' :: PQ.DBState (Eff es)) ->
+--         st' {PQ.dbRecordLastQuery = PQ.dbRecordLastQuery st}
+--       pure result
+--     GetConnectionStats -> do
+--       dbState :: PQ.DBState (Eff es) <- get
+--       mconn <- liftIO . readMVar . PQ.unConnection $ PQ.dbConnection dbState
+--       case mconn of
+--         Nothing -> throwError $ PQ.HPQTypesError "getConnectionStats: no connection"
+--         Just cd -> return $ PQ.cdStats cd
+--     RunPreparedQuery queryName sql -> do
+--       dbState <- get
+--       (result, dbState') <- liftBase $ PQ.runPreparedQueryIO queryName sql (dbState :: PQ.DBState (Eff es))
+--       put dbState'
+--       pure result
+--     GetLastQuery -> do
+--       dbState :: PQ.DBState (Eff es) <- get
+--       pure $ PQ.dbLastQuery dbState
+--     GetTransactionSettings -> do
+--       dbState :: PQ.DBState (Eff es) <- get
+--       pure $ PQ.dbTransactionSettings dbState
+--     SetTransactionSettings settings -> modify $ \(st' :: PQ.DBState (Eff es)) ->
+--       st' {PQ.dbTransactionSettings = settings}
+--     WithNewConnection (action :: Eff localEs b) -> do
+--       runWithNewConnection $ localSeqUnlift env (\unlift -> unlift action)
+--     GetNotification time -> do
+--       dbState :: PQ.DBState (Eff es) <- get
+--       liftBase $ PQ.getNotificationIO dbState time
+--   where
+--     runWithState :: Eff (State (PQ.DBState (Eff es)) : es) a -> Eff es a
+--     runWithState eff =
+--       PQ.withConnection (PQ.unConnectionSource connectionSource) $ \conn -> do
+--         let dbState0 = mkDBState conn transactionSettings
+--             -- TODO: Is it ok that we look at transactionSettings?  Probably
+--             -- yes, since at this point we have no access to any other settings.
+--             -- However, make sure about that.
+--             eff' = if PQ.tsAutoTransaction transactionSettings
+--               then withTransaction' (transactionSettings { PQ.tsAutoTransaction = False }) eff
+--               else eff
+--         evalState dbState0 eff' :: Eff es a
+--     runWithNewConnection ::
+--       Eff (State (PQ.DBState (Eff es)) : es) b ->
+--       Eff (State (PQ.DBState (Eff es)) : es) b
+--     runWithNewConnection action = do
+--       dbState :: PQ.DBState (Eff es) <- get
+--       result <- PQ.withConnection (PQ.unConnectionSource connectionSource) $ \newConn -> do
+--         -- TODO: We do not pass the current connection source to the new DB
+--         -- state, which differs from the original code.
+--         put $ mkDBState newConn (PQ.dbTransactionSettings dbState)
+--         action
+--       put dbState
+--       pure result

--- a/src/Effectful/HPQTypes.hs
+++ b/src/Effectful/HPQTypes.hs
@@ -167,7 +167,8 @@ instance (IOE :> es, Error PQ.HPQTypesError :> es) => PQ.MonadDB (DBEff es) wher
     (result, dbState') <- liftBase $ PQ.runQueryIO sql dbState
     put dbState'
     pure result
-  getQueryResult = PQ.dbQueryResult <$> get
+  getQueryResult =
+    get >>= \dbState -> pure $ PQ.dbQueryResult dbState
   clearQueryResult =
     modify $ \st -> st {PQ.dbQueryResult = Nothing}
   getConnectionStats = do

--- a/src/Effectful/HPQTypes.hs
+++ b/src/Effectful/HPQTypes.hs
@@ -123,16 +123,13 @@ mkDBState connectionSource conn ts =
     , PQ.dbQueryResult = Nothing
     }
 
--- TODO NOW: Provisional workaround to make tests pass
 handleAutoTransaction ::
   PQ.TransactionSettings ->
   (PQ.TransactionSettings -> m a -> m a) ->
   m a ->
   m a
--- handleAutoTransaction _transactionSettings _withTransaction action = action
-
 handleAutoTransaction transactionSettings withTransaction action =
-  -- TODO NOW: Why don't we have to set `tsAutoTransaction` to `False` in the
+  -- REVIEW: Why don't we have to set `tsAutoTransaction` to `False` in the
   -- context of the `action`?
   if PQ.tsAutoTransaction transactionSettings
     then withTransaction (transactionSettings {PQ.tsAutoTransaction = False}) action

--- a/src/Effectful/HPQTypes.hs
+++ b/src/Effectful/HPQTypes.hs
@@ -154,7 +154,7 @@ instance (IOE :> es) => MonadBase IO (DBEff es) where
 
 -- Convenience instance to avoid writing @DBEff get@ etc.
 -- REVIEW: This comes with the mtl dependency, so maybe it isn't worth it?  The
--- `get`, `put`, and `modify` gelper functions could be also defined
+-- `get`, `put`, and `modify` helper functions could be also defined
 -- explicitely.
 instance MonadState (PQ.DBState (DBEff es)) (DBEff es) where
   get = DBEff State.get

--- a/src/Effectful/HPQTypes.hs
+++ b/src/Effectful/HPQTypes.hs
@@ -16,7 +16,7 @@
 
 module Effectful.HPQTypes
   ( DB (..)
-  , runEffectDB
+  , runDB
   )
 where
 
@@ -66,14 +66,14 @@ instance DB :> es => PQ.MonadDB (Eff es) where
   getNotification = send . GetNotification
 
 -- | The default effect runner.
-runEffectDB ::
+runDB ::
   forall es a.
   (IOE :> es, Error PQ.HPQTypesError :> es) =>
   PQ.ConnectionSourceM (Eff es) ->
   PQ.TransactionSettings ->
   Eff (DB : es) a ->
   Eff es a
-runEffectDB connectionSource transactionSettings =
+runDB connectionSource transactionSettings =
   reinterpret runWithState $ \env -> \case
     RunQuery sql -> unDBEff $ PQ.runQuery sql
     GetQueryResult -> unDBEff PQ.getQueryResult

--- a/src/Effectful/HPQTypes.hs
+++ b/src/Effectful/HPQTypes.hs
@@ -129,14 +129,14 @@ handleAutoTransaction ::
   (PQ.TransactionSettings -> m a -> m a) ->
   m a ->
   m a
-handleAutoTransaction _transactionSettings _withTransaction action = action
+-- handleAutoTransaction _transactionSettings _withTransaction action = action
 
--- handleAutoTransaction transactionSettings withTransaction action =
---   -- TODO NOW: Why don't we have to set `tsAutoTransaction` to `False` in the
---   -- context of the `action`?
---   if PQ.tsAutoTransaction transactionSettings
---     then withTransaction (transactionSettings {PQ.tsAutoTransaction = False}) action
---     else action
+handleAutoTransaction transactionSettings withTransaction action =
+  -- TODO NOW: Why don't we have to set `tsAutoTransaction` to `False` in the
+  -- context of the `action`?
+  if PQ.tsAutoTransaction transactionSettings
+    then withTransaction (transactionSettings {PQ.tsAutoTransaction = False}) action
+    else action
 
 ---------------------------------------------------
 -- Internal effect stack

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,47 +25,74 @@ tests :: TestTree
 tests =
   testGroup
     "tests"
-    [testCase "test PrintConnectionStats" testPrintConnectionStats]
+    [ testCase "test getLastQuery" testGetLastQuery
+    , testCase "test withFrozenLastQuery" testWithFrozenLastQuery
+    , testCase "test connection stats retrieval with new connection" testConnectionStatsWithNewConnection
+    ]
 
-testPrintConnectionStats :: Assertion
-testPrintConnectionStats = do
+testGetLastQuery :: Assertion
+testGetLastQuery = do
   dbUrl <- T.pack <$> getEnv "DATABASE_URL"
   let connectionSource :: ConnectionSource [MonadBase IO, MonadMask]
       connectionSource = simpleSource $ ConnectionSettings dbUrl Nothing []
-      transactionSettings = defaultTransactionSettings
-      sql = "SELECT 1"
-      program :: Eff '[DB, Error HPQTypesError, IOE] ()
-      program = do
-        rowNo <- runQuery $ mkSQL sql
-        liftBase $ putStr "Row number: " >> print rowNo
+  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB connectionSource defaultTransactionSettings $ do
+    do
+      -- Run the first query and perform some basic sanity checks
+      let sql = mkSQL "SELECT 1"
+      rowNo <- runQuery sql
+      liftBase $ assertEqual "One row should be retrieved" 1 rowNo
+      queryResult :: [Int32] <- fetchMany runIdentity
+      liftBase $ assertEqual "Result should be [1]" [1] queryResult
+      (SomeSQL lastQuery) <- getLastQuery
+      liftBase $ assertEqual "SQL don't match" (show sql) (show lastQuery)
+    do
+      -- Run the second query and check that `getLastQuery` gives updated result
+      let newSQL = mkSQL "SELECT 2"
+      void $ runQuery newSQL
+      (SomeSQL newLastQuery) <- getLastQuery
+      liftBase $ assertEqual "SQL don't match" (show newSQL) (show newLastQuery)
 
-        queryResult :: [Int32] <- fetchMany runIdentity
-        liftBase $ putStr "Result(s): " >> print queryResult
+testWithFrozenLastQuery :: Assertion
+testWithFrozenLastQuery = do
+  dbUrl <- T.pack <$> getEnv "DATABASE_URL"
+  let connectionSource :: ConnectionSource [MonadBase IO, MonadMask]
+      connectionSource = simpleSource $ ConnectionSettings dbUrl Nothing []
+  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB connectionSource defaultTransactionSettings $ do
+    let sql = mkSQL "SELECT 1"
+    void $ runQuery sql
+    withFrozenLastQuery $ do
+      void . runQuery $ mkSQL "SELECT 2"
+      getLastQuery >>= \(SomeSQL lastQuery) ->
+        liftBase $ assertEqual "The last query before freeze should be reported" (show sql) (show lastQuery)
+    getLastQuery >>= \(SomeSQL lastQuery) ->
+      liftBase $ assertEqual "The last query before freeze should be reported" (show sql) (show lastQuery)
 
-        (SomeSQL lq) <- getLastQuery
-        withFrozenLastQuery $ do
-          let newSQL = "SELECT 2"
-          void . runQuery $ mkSQL newSQL
-          (SomeSQL newLq) <- getLastQuery
-          liftIO $ assertEqual "SQL don't match" (show newLq) (show $ mkSQL sql)
-        liftIO $ assertEqual "SQL don't match" (show lq) (show $ mkSQL sql)
-
+testConnectionStatsWithNewConnection :: Assertion
+testConnectionStatsWithNewConnection = do
+  dbUrl <- T.pack <$> getEnv "DATABASE_URL"
+  let connectionSource :: ConnectionSource [MonadBase IO, MonadMask]
+      connectionSource = simpleSource $ ConnectionSettings dbUrl Nothing []
+      transactionSettings =
+        defaultTransactionSettings
+          { tsIsolationLevel = ReadCommitted
+          , tsAutoTransaction = False
+          }
+  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB connectionSource transactionSettings $ do
+    do
+      void . runQuery $ mkSQL "SELECT 1"
+      void . runQuery $ mkSQL "SELECT 2"
+      connectionStats <- getConnectionStats
+      liftBase $ assertEqual "Incorrect connection stats" (ConnectionStats 2 2 2 0) connectionStats
+    do
+      void . runQuery $ mkSQL "CREATE TABLE some_table (field INT)"
+      void . runQuery $ mkSQL "BEGIN"
+      void . runQuery $ mkSQL "INSERT INTO some_table VALUES (1)"
+      withNewConnection $ do
         connectionStats <- getConnectionStats
-        liftIO $ putStr "Connection stats: " >> print connectionStats
-
-        setTransactionSettings $ defaultTransactionSettings {tsIsolationLevel = ReadCommitted}
-        void . runQuery $ mkSQL "CREATE TABLE some_table (field INT)"
-        void . runQuery $ mkSQL "BEGIN"
-        void . runQuery $ mkSQL "INSERT INTO some_table VALUES (1)"
-        withNewConnection $ do
-          newConnectionStats <- getConnectionStats
-          liftIO $ putStr "New connection stats: " >> print newConnectionStats
-
-          setTransactionSettings $ defaultTransactionSettings {tsIsolationLevel = ReadCommitted}
-          noOfResults <- runQuery $ mkSQL "SELECT * FROM some_table"
-          liftIO $ assertEqual "Results should not be visible yet" 0 noOfResults
-        void . runQuery $ mkSQL "COMMIT"
+        liftBase $ assertEqual "Connection stats should be reset" (ConnectionStats 0 0 0 0) connectionStats
         noOfResults <- runQuery $ mkSQL "SELECT * FROM some_table"
-        liftIO $ assertEqual "Results should be visible" 1 noOfResults
-        void . runQuery $ mkSQL "DROP TABLE some_table"
-  (runEff . runErrorNoCallStack @HPQTypesError $ runEffectDB connectionSource transactionSettings program) >>= print
+        liftBase $ assertEqual "Results should not be visible yet" 0 noOfResults
+      void . runQuery $ mkSQL "COMMIT"
+      noOfResults <- runQuery $ mkSQL "SELECT * FROM some_table"
+      liftBase $ assertEqual "Results should be visible" 1 noOfResults
+      void . runQuery $ mkSQL "DROP TABLE some_table"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -35,7 +35,7 @@ testGetLastQuery = do
   dbUrl <- T.pack <$> getEnv "DATABASE_URL"
   let connectionSource :: ConnectionSource [MonadBase IO, MonadMask]
       connectionSource = simpleSource $ ConnectionSettings dbUrl Nothing []
-  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB (unConnectionSource connectionSource) defaultTransactionSettings $ do
+  void . runEff . runErrorNoCallStack @HPQTypesError . runDB (unConnectionSource connectionSource) defaultTransactionSettings $ do
     do
       -- Run the first query and perform some basic sanity checks
       let sql = mkSQL "SELECT 1"
@@ -57,7 +57,7 @@ testWithFrozenLastQuery = do
   dbUrl <- T.pack <$> getEnv "DATABASE_URL"
   let connectionSource :: ConnectionSource [MonadBase IO, MonadMask]
       connectionSource = simpleSource $ ConnectionSettings dbUrl Nothing []
-  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB (unConnectionSource connectionSource) defaultTransactionSettings $ do
+  void . runEff . runErrorNoCallStack @HPQTypesError . runDB (unConnectionSource connectionSource) defaultTransactionSettings $ do
     let sql = mkSQL "SELECT 1"
     void $ runQuery sql
     withFrozenLastQuery $ do
@@ -77,7 +77,7 @@ testConnectionStatsWithNewConnection = do
           { tsIsolationLevel = ReadCommitted
           , tsAutoTransaction = False
           }
-  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB (unConnectionSource connectionSource) transactionSettings $ do
+  void . runEff . runErrorNoCallStack @HPQTypesError . runDB (unConnectionSource connectionSource) transactionSettings $ do
     do
       void . runQuery $ mkSQL "SELECT 1"
       void . runQuery $ mkSQL "SELECT 2"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -35,7 +35,7 @@ testGetLastQuery = do
   dbUrl <- T.pack <$> getEnv "DATABASE_URL"
   let connectionSource :: ConnectionSource [MonadBase IO, MonadMask]
       connectionSource = simpleSource $ ConnectionSettings dbUrl Nothing []
-  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB connectionSource defaultTransactionSettings $ do
+  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB (unConnectionSource connectionSource) defaultTransactionSettings $ do
     do
       -- Run the first query and perform some basic sanity checks
       let sql = mkSQL "SELECT 1"
@@ -57,7 +57,7 @@ testWithFrozenLastQuery = do
   dbUrl <- T.pack <$> getEnv "DATABASE_URL"
   let connectionSource :: ConnectionSource [MonadBase IO, MonadMask]
       connectionSource = simpleSource $ ConnectionSettings dbUrl Nothing []
-  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB connectionSource defaultTransactionSettings $ do
+  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB (unConnectionSource connectionSource) defaultTransactionSettings $ do
     let sql = mkSQL "SELECT 1"
     void $ runQuery sql
     withFrozenLastQuery $ do
@@ -77,7 +77,7 @@ testConnectionStatsWithNewConnection = do
           { tsIsolationLevel = ReadCommitted
           , tsAutoTransaction = False
           }
-  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB connectionSource transactionSettings $ do
+  void . runEff . runErrorNoCallStack @HPQTypesError . runEffectDB (unConnectionSource connectionSource) transactionSettings $ do
     do
       void . runQuery $ mkSQL "SELECT 1"
       void . runQuery $ mkSQL "SELECT 2"


### PR DESCRIPTION
An attempt to resolve #22 using a newtype wrapper over the internal DB effect stack.  The wrapper itself has a `MonadDB` instance which avoids the re-implementation of `withTransaction`.